### PR TITLE
enable spi: fix the error in "insmod esp8089-spi.ko"

### DIFF
--- a/arch/arm/dts/suniv-f1c200s-xddcore-zero.dts
+++ b/arch/arm/dts/suniv-f1c200s-xddcore-zero.dts
@@ -68,3 +68,11 @@
 &usbphy {
 	status = "okay";
 };
+
+&spi0 {
+	status = "okay";
+};
+
+&spi1 {
+	status = "okay";
+};

--- a/arch/arm/dts/suniv-f1c200s-xddcore-zero.dts
+++ b/arch/arm/dts/suniv-f1c200s-xddcore-zero.dts
@@ -71,6 +71,8 @@
 
 &spi0 {
 	status = "okay";
+	pinctrl-0 = <&spi0_pc_pins>;
+	pinctrl-names = "default";
 };
 
 &spi1 {


### PR DESCRIPTION
Previously with the dtb compiled, insmod of esp8089.ko will cast error like this. This is because spi is not enabled in dts.
```bash
root@nekos:~# insmod /etc/esp8089-spi.ko
[  104.042968] esp8089_spi: loading out-of-tree module taints kernel.
[  104.068539] esp8089_spi: EAGLE DRIVER VER bdf5087c3deb
[  104.074048] suniv-f1c100s-pinctrl 1c20800.pinctrl: supply vcc-pd not found, using dummy regulator
[  104.694323] esp8089_spi: cs begin
[  104.697877] suniv-f1c100s-pinctrl 1c20800.pinctrl: supply vcc-pc not found, using dummy regulator
[  104.707107] esp8089_spi: cs end
[  104.710380] esp8089_spi: FAILED to find master
[  104.714828] esp8089_spi: FAILED to create slave
[  104.719458] 8<--- cut here ---
[  104.722534] Unable to handle kernel NULL pointer dereference at virtual address 000001c0
[  104.730688] pgd = 2511e953
[  104.733405] [000001c0] *pgd=00000000
[  104.737004] Internal error: Oops: 5 [#1] ARM
[  104.741270] Modules linked in: esp8089_spi(O+)
[  104.745750] CPU: 0 PID: 182 Comm: insmod Tainted: G           O      5.10.186+ #1
[  104.753211] Hardware name: Allwinner suniv Family
[  104.757950] PC is at spi_setup+0x4/0x260
[  104.762149] LR is at sif_platform_new_device+0x68/0xd0 [esp8089_spi]
[  104.768504] pc : [<c04f372c>]    lr : [<bf00026c>]    psr: 60000013
[  104.774759] sp : c00b9d90  ip : 00000000  fp : bf00f4a0
[  104.779975] r10: 00000003  r9 : 00000001  r8 : 00000000
[  104.785195] r7 : bf03bba4  r6 : 00000000  r5 : bf03bba0  r4 : bf00f400
[  104.791712] r3 : 9ceb17c6  r2 : 9ceb17c6  r1 : c0b6e3d4  r0 : 00000000
[  104.798230] Flags: nZCv  IRQs on  FIQs on  Mode SVC_32  ISA ARM  Segment none
[  104.805353] Control: 0005317f  Table: 800e0000  DAC: 00000051
[  104.811095] Process insmod (pid: 182, stack limit = 0xf5cf2800)
[  104.817006] Stack: (0xc00b9d90 to 0xc00ba000)
[  104.821371] 9d80:                                     bf00f400 bf03bba0 00000000 bf00026c
[  104.829548] 9da0: bf03bba0 bf00f000 00000000 bf0410a0 00000000 c0b9d000 c0b03228 ffffe000
[  104.837723] 9dc0: bf041000 00000000 00000001 00000028 00000124 c0101dc0 c00b9dec 00000000
[  104.845899] 9de0: c3f7b520 c0b97448 ffe00000 c3f7b524 c3f7b564 9ceb17c6 00000024 20000013
[  104.854074] 9e00: c3f7b340 00080000 00000000 00000000 00000001 c01d3e6c 20000013 c00ec020
[  104.862250] 9e20: 00000045 9ceb17c6 bf03b9e0 bf03b9e0 c00ec020 c15731c0 c15731e4 c078123c
[  104.870425] 9e40: 00000001 c00b9f38 c00b9f38 bf03b9e0 00000001 c0173c58 bf03b9ec 00007fff
[  104.878601] 9e60: bf03b9e0 c0171324 bf03ba28 bf0488ad bf03bad4 bf03b9e0 00000000 bf03bb80
[  104.886779] 9e80: bf043000 c0801b30 c4a80aec 9ceb17c6 c26293c0 c0b03228 00044aec c00b9f34
[  104.894954] 9ea0: 00000000 00000000 00000000 00000000 00000000 00000000 6e72656b 00006c65
[  104.903126] 9ec0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[  104.911301] 9ee0: 00000000 00000000 00000000 00000000 00000000 9ceb17c6 c00b9f34 00000000
[  104.919476] 9f00: c0b03228 004bf358 00000003 c0100268 c00b8000 00000000 004d2718 c01744d0
[  104.927652] 9f20: c00b9f34 7fffffff 00000000 00000002 00044aec c4a3c000 c4a49d65 c4a76800
[  104.935828] 9f40: c4a3c000 00044aec c4a8054c c4a803ec c4a7a7fc 0003c000 0003de60 00007668
[  104.944003] 9f60: 0003f0be 00000000 00000000 00000000 00007658 00000021 00000022 00000017
[  104.952177] 9f80: 00000000 00000011 00000000 9ceb17c6 00000000 bead4d44 00000002 161a8a00
[  104.960352] 9fa0: 0000017b c0100060 bead4d44 00000002 00000003 004bf358 00000000 00000000
[  104.968526] 9fc0: bead4d44 00000002 161a8a00 0000017b 004d4ef0 00000000 00000002 004d2718
[  104.976701] 9fe0: bead4b68 bead4b58 004b5358 b6c2d980 60000010 00000003 00000000 00000000
[  104.985153] [<c04f372c>] (spi_setup) from [<bf00f000>] (esp_msg_level+0x0/0xffffd000 [esp8089_spi])
[  104.994210] Code: e12fff1e e59401b0 eaffffd5 e92d4070 (e59031c0) 
[  105.000460] ---[ end trace ee7fb712df93a9f1 ]---
```